### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ module.exports = function (object, path, value) {
 
     var key = paths[index];
 
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return object;
+    }
+
     if (isObject(nested)) {
 
       var newValue = value;


### PR DESCRIPTION
`object-set` is vulnerable to `Prototype Pollution`.

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```js
// poc.js
var objectSet = require("object-set")
objectSet({}, '__proto__.polluted', 'Yes! Its Polluted');
console.log(polluted);
```

2. Execute the following commands in another terminal:

```bash
npm i object-set # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Yes! Its Polluted
```

![object-setPOC](https://user-images.githubusercontent.com/7505980/95336291-29e86480-08b9-11eb-896d-7d99acf88b28.png)


### 🔥 Proof of Fix (PoF) *

After fix execution returns: polluted is not defined

![object-setPOF](https://user-images.githubusercontent.com/7505980/95336300-2e148200-08b9-11eb-8013-85c3a9e57fb9.png)


### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected